### PR TITLE
Return ChildProcess to caller

### DIFF
--- a/fixture.js
+++ b/fixture.js
@@ -9,6 +9,10 @@ cli.input.forEach(function (input) {
 	log(input);
 });
 
+if (cli.flags.cat) {
+	process.stdin.pipe(process.stdout);
+}
+
 if (cli.flags.exit) {
 	process.exit(1);
 }

--- a/index.js
+++ b/index.js
@@ -6,8 +6,9 @@ module.exports = function (file, args, options) {
 		return Promise.reject(new Error('Expected a file'));
 	}
 
-	return new Promise(function (resolve, reject) {
-		execFile(file, args, options, function (err, stdout, stderr) {
+	var child;
+	var promise = new Promise(function (resolve, reject) {
+		child = execFile(file, args, options, function (err, stdout, stderr) {
 			if (err) {
 				err.stdout = stdout;
 				err.stderr = stderr;
@@ -18,4 +19,7 @@ module.exports = function (file, args, options) {
 			resolve({stdout: stdout, stderr: stderr});
 		});
 	});
+	child.then = promise.then.bind(promise);
+	child.catch = promise.catch.bind(promise);
+	return child;
 };

--- a/test.js
+++ b/test.js
@@ -13,6 +13,13 @@ test('stderr', async t => {
 	t.is(stderr, 'foo\n');
 });
 
+test('cat', async t => {
+	const result = fn('./fixture.js', ['--cat']);
+	result.stdin.end('foo\n');
+	const {stdout} = await result;
+	t.is(stdout, 'foo\n');
+});
+
 test('exit', async t => {
 	t.throws(fn('./fixture.js', ['--exit']), Error);
 });


### PR DESCRIPTION
I am considering using `get-exec-file` in a few of my projects and realized that it is wouldn't work due to lack of access to the created `ChildProcess`.  The utility of `get-exec-file` is somewhat limited if the created `ChildProcess` is not returned to the caller, which can no longer get the child PID, write to or close `stdin`, or send signals to the child process.  This PR is one way to address the limitation, without breaking the current API, by return the `ChildProcess` as a property on the returned `Promise`.

Thanks for considering,
Kevin